### PR TITLE
Fix: Add path-based DID endpoint format support

### DIFF
--- a/docs/DID-ENDPOINT.md
+++ b/docs/DID-ENDPOINT.md
@@ -1,20 +1,34 @@
 # Nostr DID Endpoint
 
-This server now supports the Nostr DID Method specification, providing a `.well-known/did.json` endpoint for generating DID documents from Nostr public keys.
+This server now supports the Nostr DID Method specification, providing DID document endpoints for generating DID documents from Nostr public keys.
 
 ## Usage
 
-### Request
+The server supports two URL patterns for accessing DID documents:
+
+### Method 1: Query Parameter
 ```
 GET /.well-known/did.json?pubkey={hex_public_key}
 ```
 
-### Parameters
-- `pubkey` (required): A 64-character hexadecimal Nostr public key
+### Method 2: Path Parameter
+```
+GET /.well-known/did/nostr/{hex_public_key}.json
+```
 
-### Example Request
+### Parameters
+- `hex_public_key`: A 64-character hexadecimal Nostr public key
+
+### Example Requests
+
+#### Query Parameter Format
 ```bash
 curl "http://localhost:3000/.well-known/did.json?pubkey=124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2"
+```
+
+#### Path Parameter Format
+```bash
+curl "http://localhost:3000/.well-known/did/nostr/124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2.json"
 ```
 
 ### Example Response

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function createServer ({ port, useHttps = false }) {
   fi.register(fastifyWebsocket)
   
   // DID endpoint - serves DID documents for Nostr public keys
+  // Support query parameter format: /.well-known/did.json?pubkey={pubkey}
   fi.get('/.well-known/did.json', async (request, reply) => {
     const { pubkey } = request.query
     
@@ -34,6 +35,31 @@ function createServer ({ port, useHttps = false }) {
         message: 'Please provide a pubkey query parameter with a 64-character hex public key'
       })
     }
+    
+    if (!isValidPubkey(pubkey)) {
+      return reply.code(400).send({
+        error: 'Invalid pubkey format',
+        message: 'Public key must be a 64-character hexadecimal string'
+      })
+    }
+    
+    try {
+      const didDocument = generateDIDDocument(pubkey)
+      return reply
+        .header('Content-Type', 'application/json')
+        .send(didDocument)
+    } catch (error) {
+      console.error('Error generating DID document:', error)
+      return reply.code(500).send({
+        error: 'Failed to generate DID document',
+        message: error.message
+      })
+    }
+  })
+  
+  // DID endpoint - path parameter format: /.well-known/did/nostr/{pubkey}.json
+  fi.get('/.well-known/did/nostr/:pubkey.json', async (request, reply) => {
+    const { pubkey } = request.params
     
     if (!isValidPubkey(pubkey)) {
       return reply.code(400).send({


### PR DESCRIPTION
## Summary
Adds support for the path-based URL format `/.well-known/did/nostr/{pubkey}.json` alongside the existing query parameter format.

## Problem
The server was returning 404 errors when trying to access DID documents using the RESTful path-based URL format, as reported in #14.

## Solution
- Added a new route handler for `/.well-known/did/nostr/:pubkey.json`
- Maintains backwards compatibility with existing query parameter format
- Both formats return identical DID documents

## Supported Formats
1. **Query parameter**: `GET /.well-known/did.json?pubkey={pubkey}`
2. **Path parameter**: `GET /.well-known/did/nostr/{pubkey}.json`

## Testing
Both formats work identically:
```bash
# Query format
curl "http://localhost:4444/.well-known/did.json?pubkey=33bfd6d2a5865444204dcd0cc9bfd2f68af372cd51cfcacc6c3a0ad6bc4c9482"

# Path format  
curl "http://localhost:4444/.well-known/did/nostr/33bfd6d2a5865444204dcd0cc9bfd2f68af372cd51cfcacc6c3a0ad6bc4c9482.json"
```

Fixes #14