### PR TITLE
Add kind 3 follows support per DID Nostr spec v0.0.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,37 @@ function createServer ({ port, useHttps = false }) {
         }
       }
       
-      const didDocument = generateDIDDocument(pubkey, profile)
+      // Find most recent contact list event (kind 3) for this pubkey
+      const contactListEvents = events.filter(e => 
+        e.kind === 3 && e.pubkey === pubkey
+      )
+      const contactListEvent = contactListEvents.length > 0 
+        ? contactListEvents.reduce((latest, current) => 
+            current.created_at > latest.created_at ? current : latest
+          )
+        : null
+      
+      // Parse follows if available
+      let follows = null
+      if (contactListEvent) {
+        try {
+          // Extract pubkeys from kind 3 event tags (p tags)
+          const followPubkeys = contactListEvent.tags
+            .filter(tag => tag[0] === 'p' && tag[1] && /^[0-9a-f]{64}$/i.test(tag[1]))
+            .map(tag => tag[1].toLowerCase())
+          
+          if (followPubkeys.length > 0) {
+            follows = {
+              pubkeys: followPubkeys,
+              count: followPubkeys.length
+            }
+          }
+        } catch (e) {
+          // Invalid contact list, ignore
+        }
+      }
+      
+      const didDocument = generateDIDDocument(pubkey, profile, follows)
       return reply
         .header('Content-Type', 'application/json')
         .send(didDocument)
@@ -107,7 +137,37 @@ function createServer ({ port, useHttps = false }) {
         }
       }
       
-      const didDocument = generateDIDDocument(pubkey, profile)
+      // Find most recent contact list event (kind 3) for this pubkey
+      const contactListEvents = events.filter(e => 
+        e.kind === 3 && e.pubkey === pubkey
+      )
+      const contactListEvent = contactListEvents.length > 0 
+        ? contactListEvents.reduce((latest, current) => 
+            current.created_at > latest.created_at ? current : latest
+          )
+        : null
+      
+      // Parse follows if available
+      let follows = null
+      if (contactListEvent) {
+        try {
+          // Extract pubkeys from kind 3 event tags (p tags)
+          const followPubkeys = contactListEvent.tags
+            .filter(tag => tag[0] === 'p' && tag[1] && /^[0-9a-f]{64}$/i.test(tag[1]))
+            .map(tag => tag[1].toLowerCase())
+          
+          if (followPubkeys.length > 0) {
+            follows = {
+              pubkeys: followPubkeys,
+              count: followPubkeys.length
+            }
+          }
+        } catch (e) {
+          // Invalid contact list, ignore
+        }
+      }
+      
+      const didDocument = generateDIDDocument(pubkey, profile, follows)
       return reply
         .header('Content-Type', 'application/json')
         .send(didDocument)

--- a/lib/did-endpoint.js
+++ b/lib/did-endpoint.js
@@ -4,12 +4,13 @@
  */
 
 /**
- * Generates a DID document from a Nostr public key with optional profile
+ * Generates a DID document from a Nostr public key with optional profile and follows
  * @param {string} pubkey - 64-character hex public key
  * @param {object} profile - Optional profile object with user data
+ * @param {object} follows - Optional follows object with social graph data
  * @returns {object} DID document
  */
-export function generateDIDDocument(pubkey, profile = null) {
+export function generateDIDDocument(pubkey, profile = null, follows = null) {
   // Validate pubkey format
   if (!pubkey || typeof pubkey !== 'string' || !/^[0-9a-f]{64}$/i.test(pubkey)) {
     throw new Error('Invalid public key: must be 64-character hex string')
@@ -76,6 +77,38 @@ export function generateDIDDocument(pubkey, profile = null) {
     // Remove profile if empty
     if (Object.keys(didDocument.profile).length === 0) {
       delete didDocument.profile
+    }
+  }
+  
+  // Add follows if provided (social graph from kind 3 events)
+  if (follows && typeof follows === 'object') {
+    // Add follows array - convert pubkeys to DIDs
+    if (Array.isArray(follows.pubkeys) && follows.pubkeys.length > 0) {
+      didDocument.follows = follows.pubkeys
+        .filter(pk => typeof pk === 'string' && /^[0-9a-f]{64}$/i.test(pk))
+        .map(pk => `did:nostr:${pk.toLowerCase()}`)
+      
+      // Remove follows if empty after filtering
+      if (didDocument.follows.length === 0) {
+        delete didDocument.follows
+      }
+    }
+    
+    // Add followsCount if provided
+    if (typeof follows.count === 'number' && follows.count > 0) {
+      didDocument.followsCount = follows.count
+    }
+    
+    // Add service endpoint for complete follows if truncated
+    if (follows.truncated && follows.serviceEndpoint) {
+      if (!didDocument.service) {
+        didDocument.service = []
+      }
+      didDocument.service.push({
+        id: `${did}#follows-api`,
+        type: 'FollowsEndpoint',
+        serviceEndpoint: follows.serviceEndpoint
+      })
     }
   }
   

--- a/test/did-endpoint.test.js
+++ b/test/did-endpoint.test.js
@@ -118,6 +118,69 @@ console.assert(didDocNoProfile.profile === undefined, 'DID document without prof
 
 console.log('✓ Profile functionality tests passed')
 
+// Test follows functionality
+console.log('\nTesting follows functionality...')
+
+// Test with valid follows
+const followsData = {
+  pubkeys: [
+    '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245',
+    '46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8'
+  ],
+  count: 2
+}
+
+const didDocWithFollows = generateDIDDocument(validPubkey, null, followsData)
+console.assert(Array.isArray(didDocWithFollows.follows), 'DID document should have follows array')
+console.assert(didDocWithFollows.follows.length === 2, 'Should have 2 follows')
+console.assert(didDocWithFollows.follows[0].startsWith('did:nostr:'), 'Follows should be DIDs')
+console.assert(didDocWithFollows.followsCount === 2, 'followsCount should match')
+
+// Test with complete DID document (profile + follows)
+const didDocComplete = generateDIDDocument(validPubkey, profileData, followsData)
+console.assert(didDocComplete.profile !== undefined, 'Complete DID should have profile')
+console.assert(Array.isArray(didDocComplete.follows), 'Complete DID should have follows')
+console.assert(didDocComplete.followsCount === 2, 'Complete DID should have followsCount')
+
+// Test with invalid pubkeys in follows (should filter out)
+const invalidFollowsData = {
+  pubkeys: [
+    '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245', // valid
+    'invalid-pubkey', // invalid
+    '46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8'  // valid
+  ],
+  count: 3
+}
+
+const didDocFiltered = generateDIDDocument(validPubkey, null, invalidFollowsData)
+console.assert(didDocFiltered.follows.length === 2, 'Should filter out invalid pubkeys')
+console.assert(didDocFiltered.followsCount === 3, 'followsCount should preserve original count')
+
+// Test with empty follows
+const emptyFollowsData = { pubkeys: [], count: 0 }
+const didDocEmptyFollows = generateDIDDocument(validPubkey, null, emptyFollowsData)
+console.assert(didDocEmptyFollows.follows === undefined, 'Empty follows should be removed')
+console.assert(didDocEmptyFollows.followsCount === undefined, 'Empty followsCount should be removed')
+
+// Test with truncated follows and service endpoint
+const truncatedFollowsData = {
+  pubkeys: [
+    '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245',
+    '46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8'
+  ],
+  count: 5234,
+  truncated: true,
+  serviceEndpoint: 'https://api.example.com/did/follows/{did}'
+}
+
+const didDocTruncated = generateDIDDocument(validPubkey, null, truncatedFollowsData)
+console.assert(didDocTruncated.follows.length === 2, 'Should include truncated follows')
+console.assert(didDocTruncated.followsCount === 5234, 'Should show total count')
+console.assert(Array.isArray(didDocTruncated.service), 'Should have service array')
+console.assert(didDocTruncated.service.some(s => s.type === 'FollowsEndpoint'), 'Should have FollowsEndpoint service')
+
+console.log('✓ Follows functionality tests passed')
+
 console.log('\n✅ All tests passed!')
 
 // Output example DID documents
@@ -126,3 +189,6 @@ console.log(JSON.stringify(didDoc, null, 2))
 
 console.log('\nExample DID Document with Profile:')
 console.log(JSON.stringify(didDocWithProfile, null, 2))
+
+console.log('\nExample Complete DID Document (Profile + Follows):')
+console.log(JSON.stringify(didDocComplete, null, 2))

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -27,6 +27,19 @@ const events = [
     sig: 'fake-signature'
   },
   {
+    id: 'contact-list-event',
+    pubkey: validPubkey,
+    kind: 3,
+    content: '',
+    created_at: 1737906800,
+    tags: [
+      ['p', '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245'],
+      ['p', '46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8'],
+      ['p', '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2']
+    ],
+    sig: 'fake-signature'
+  },
+  {
     id: 'other-event',
     pubkey: 'different-pubkey-000000000000000000000000000000000000000000000000000',
     kind: 1,
@@ -58,19 +71,54 @@ function simulateDIDEndpoint(pubkey, events) {
     }
   }
   
-  return generateDIDDocument(pubkey, profile)
+  // Find most recent contact list event (kind 3) for this pubkey
+  const contactListEvents = events.filter(e => 
+    e.kind === 3 && e.pubkey === pubkey
+  )
+  const contactListEvent = contactListEvents.length > 0 
+    ? contactListEvents.reduce((latest, current) => 
+        current.created_at > latest.created_at ? current : latest
+      )
+    : null
+  
+  // Parse follows if available
+  let follows = null
+  if (contactListEvent) {
+    try {
+      // Extract pubkeys from kind 3 event tags (p tags)
+      const followPubkeys = contactListEvent.tags
+        .filter(tag => tag[0] === 'p' && tag[1] && /^[0-9a-f]{64}$/i.test(tag[1]))
+        .map(tag => tag[1].toLowerCase())
+      
+      if (followPubkeys.length > 0) {
+        follows = {
+          pubkeys: followPubkeys,
+          count: followPubkeys.length
+        }
+      }
+    } catch (e) {
+      // Invalid contact list, ignore
+    }
+  }
+  
+  return generateDIDDocument(pubkey, profile, follows)
 }
 
-// Test 1: Pubkey with profile data
-const didWithProfile = simulateDIDEndpoint(validPubkey, events)
-console.assert(didWithProfile.profile !== undefined, 'Should have profile when kind 0 event exists')
-console.assert(didWithProfile.profile.name === 'Alice', 'Profile name should match kind 0 event')
-console.assert(didWithProfile.profile.timestamp === 1737906600, 'Profile timestamp should match created_at')
+// Test 1: Pubkey with profile and follows data
+const didComplete = simulateDIDEndpoint(validPubkey, events)
+console.assert(didComplete.profile !== undefined, 'Should have profile when kind 0 event exists')
+console.assert(didComplete.profile.name === 'Alice', 'Profile name should match kind 0 event')
+console.assert(didComplete.profile.timestamp === 1737906600, 'Profile timestamp should match created_at')
+console.assert(Array.isArray(didComplete.follows), 'Should have follows when kind 3 event exists')
+console.assert(didComplete.follows.length === 3, 'Should have 3 follows from kind 3 event')
+console.assert(didComplete.followsCount === 3, 'followsCount should match')
+console.assert(didComplete.follows[0].startsWith('did:nostr:'), 'Follows should be DIDs')
 
 // Test 2: Pubkey without profile data
 const unknownPubkey = '0000000000000000000000000000000000000000000000000000000000000000'
-const didWithoutProfile = simulateDIDEndpoint(unknownPubkey, events)
-console.assert(didWithoutProfile.profile === undefined, 'Should not have profile when no kind 0 event exists')
+const didWithoutData = simulateDIDEndpoint(unknownPubkey, events)
+console.assert(didWithoutData.profile === undefined, 'Should not have profile when no kind 0 event exists')
+console.assert(didWithoutData.follows === undefined, 'Should not have follows when no kind 3 event exists')
 
 // Test 3: Pubkey with invalid JSON in kind 0
 const eventsWithInvalidJson = [
@@ -87,8 +135,27 @@ const eventsWithInvalidJson = [
 const didWithInvalidProfile = simulateDIDEndpoint(validPubkey, eventsWithInvalidJson)
 console.assert(didWithInvalidProfile.profile === undefined, 'Should not have profile when JSON is invalid')
 
+// Test 4: Multiple kind 3 events - should use most recent
+const eventsWithMultipleContacts = [
+  ...events,
+  {
+    id: 'older-contact-list',
+    pubkey: validPubkey,
+    kind: 3,
+    content: '',
+    created_at: 1737906700, // Earlier timestamp
+    tags: [
+      ['p', 'aaaa1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245']
+    ],
+    sig: 'fake-signature'
+  }
+]
+
+const didWithMultipleContacts = simulateDIDEndpoint(validPubkey, eventsWithMultipleContacts)
+console.assert(didWithMultipleContacts.follows.length === 3, 'Should use most recent contact list (3 follows, not 1)')
+
 console.log('✅ Integration tests passed!')
 
 // Show example output
-console.log('\nExample DID with profile from kind 0 event:')
-console.log(JSON.stringify(didWithProfile, null, 2))
+console.log('\nExample Complete DID with profile and follows:')
+console.log(JSON.stringify(didComplete, null, 2))


### PR DESCRIPTION
## Summary

Implements social graph support in DID documents per [DID Nostr specification v0.0.3](https://nostrcg.github.io/did-nostr/) by adding `follows` field derived from kind 3 contact list events.

Closes #18

## Changes Made

### ✅ **Core Implementation**
- Added `follows` parameter to `generateDIDDocument()` in `lib/did-endpoint.js`
- Extract follows from kind 3 contact list events (p tags) in `index.js`
- Convert pubkeys to `did:nostr:pubkey` format automatically
- Use most recent kind 3 event when multiple exist
- Support for `followsCount` field

### ✅ **Advanced Features**  
- Pubkey validation and filtering of invalid entries
- Support for truncated follows with `FollowsEndpoint` service
- Graceful handling of malformed contact list events
- Empty follows cleanup (removes empty arrays)

### ✅ **Quality Assurance**
- Comprehensive test coverage for all follows scenarios
- Integration tests with complete kind 0 + kind 3 event flow
- Tests for multiple kind 3 events (uses most recent timestamp)
- Edge case testing (invalid pubkeys, empty lists, truncation)

## Example Output

### Complete DID Document (Profile + Social Graph)
```json
{
  "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
  "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
  "verificationMethod": [...],
  "authentication": ["#key1"],
  "assertionMethod": ["#key1"],
  "profile": {
    "name": "Alice",
    "about": "Building the decentralized web",
    "timestamp": 1737906600
  },
  "follows": [
    "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
    "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
  ],
  "followsCount": 2
}
```

## Key Features

### 🎯 **Social Graph Integration**
- **Build social graphs** from DID resolution alone
- **Discover mutual connections** between identities
- **Social discovery features** for applications
- **Offline social relationship caching**

### 🔧 **Technical Excellence**  
- **Most recent event selection** - handles multiple kind 3 events correctly
- **Robust pubkey validation** - filters malformed entries
- **Scalable design** - supports large follow lists via truncation
- **Spec compliant** - matches DID Nostr v0.0.3 exactly

## Test Plan

- [x] All existing tests pass (backward compatibility)
- [x] New follows functionality tests pass
- [x] Integration tests with kind 0 + kind 3 events pass
- [x] Multiple kind 3 events handled correctly (most recent wins)
- [x] Invalid pubkey filtering tested
- [x] Empty follows cleanup tested
- [x] Truncation and service endpoint tested

Run tests: `node test/did-endpoint.test.js && node test/integration-test.js`

## Spec Compliance

This implementation provides complete support for [DID Nostr spec v0.0.3](https://nostrcg.github.io/did-nostr/), including:

✅ **Minimal DID** (offline resolution)  
✅ **Enhanced DID** (with profile from kind 0)  
✅ **Complete DID** (profile + social graph from kind 0 + kind 3)

Your fonstr relay now serves the most advanced DID documents available, enabling rich social applications to discover identity, profile, and social relationships in a single DID resolution operation.