### PR TITLE
Add missing COPY for lib/ and bin/ directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN openssl req \
     -keyout privkey.pem \
     -out fullchain.pem
 
-# Copy the server script to the working directory
+# Copy the server files to the working directory
 COPY index.js ./
+COPY lib/ ./lib/
+COPY bin/ ./bin/
 
 # Expose the server port
 EXPOSE 4444


### PR DESCRIPTION
## Summary
- Adds missing `COPY lib/` and `COPY bin/` commands to Dockerfile
- Required for DID endpoint functionality and CLI entry point

Fixes #26

## Test plan
- [ ] Build Docker image: `docker build -t fonstr .`
- [ ] Verify lib/ and bin/ exist in container